### PR TITLE
feat(playground): port the Lunas playground UI

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "playground",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev", "--port", "5199", "--strictPort"],
+      "port": 5199
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ compiler-seam design, rules, and workflow.
 
 ## Status
 
-Scaffolded: a single Vite app compiling `.lunas` end-to-end. Feature work is
-tracked in [`roadmap.yml`](roadmap.yml).
+The playground works: a VS Code-like multi-file explorer, a live editor, and an
+in-browser compile + preview — all authored in `.lunas` and compiled by the real
+Lunas compiler. Next up is a Monaco editor with syntax highlighting and the
+language server (see [`roadmap.yml`](roadmap.yml)).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.0",
+    "esbuild": "^0.28.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.0",
     "vite-plugin-lunas": "file:external/lunas/packages/vite-plugin-lunas"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@types/node':
         specifier: ^20.19.0
         version: 20.19.43
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -33,9 +36,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -45,9 +60,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -57,9 +84,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -69,9 +108,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -81,9 +132,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -93,9 +156,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -105,9 +180,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -117,9 +204,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -129,11 +228,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -141,9 +264,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -153,15 +294,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -301,6 +460,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -381,70 +545,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
@@ -553,6 +795,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   fsevents@2.3.3:
     optional: true

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -15,13 +15,13 @@ milestones:
     items:
       - id: reset-to-lunas-app
         title: Reset repo to a single Vite app; submodule external/lunas at codegen-complete main
-        status: in_progress
+        status: done
       - id: consume-lunas
         title: Consume lunas + vite-plugin-lunas via file: deps; wasm:build (node + web)
-        status: in_progress
+        status: done
       - id: ci-quality-gate
         title: CI builds wasm then build/typecheck/test; release-PR script test
-        status: in_progress
+        status: done
       - id: release-automation
         title: Auto release PR (main -> beta), PR labeling
         status: done
@@ -34,13 +34,13 @@ milestones:
     items:
       - id: app-shell
         title: Material-ish app shell (reference archived Vue playground), no heavy effects
-        status: todo
+        status: done
       - id: multi-file
         title: VS Code-like multi-file management (tree, tabs, add/rename/delete, persistence)
-        status: todo
+        status: done
       - id: live-compile
         title: In-browser compile via web-target wasm worker + live preview
-        status: todo
+        status: done
 
   - id: editor-lsp
     title: Editor + language server

--- a/src/App.lunas
+++ b/src/App.lunas
@@ -1,23 +1,168 @@
 html:
-    <main class="app">
-        <h1>Lunas Playground</h1>
-        <p>Scaffold is live. Count: ${count}</p>
-        <button @click="increment()">+1</button>
-        <button @click="reset()">Reset</button>
-        <p :if="count == 0">Click the button to begin.</p>
-        <p :elseif="count > 5">You are on a roll!</p>
-        <p :else>Keep going.</p>
-    </main>
+    <div class="app">
+        <header class="topbar">
+            <span class="topbar__title">Lunas Playground</span>
+            <span class="topbar__spacer"></span>
+            <button class="btn btn--ghost" @click="openSamples()">Load samples</button>
+        </header>
 
-style:
-    .app { font-family: system-ui, sans-serif; max-width: 40rem; margin: 2rem auto; }
-    button { margin-right: 0.5rem; }
+        <div class="body">
+            <aside class="explorer">
+                <div class="explorer__head">
+                    <span>EXPLORER</span>
+                    <button class="icon-btn" title="New file" @click="addFile()">+</button>
+                </div>
+                <ul class="filelist">
+                    <li :for="f of files">
+                        <div class="file ${f.name == files[activeIndex].name ? 'file--active' : ''}">
+                            <button class="file__name" @click="selectFile(f.name)">${f.name}.lunas</button>
+                            <button class="icon-btn file__act" title="Rename" @click="renameFile(f.name)">✎</button>
+                            <button class="icon-btn file__act" title="Delete" @click="deleteFile(f.name)">✕</button>
+                        </div>
+                    </li>
+                </ul>
+            </aside>
+
+            <section class="editor">
+                <div class="tabs">
+                    <div class="tab tab--active">${files[activeIndex].name}.lunas</div>
+                </div>
+                <textarea id="code-editor" class="code" spellcheck="false" @input="onInput(event)"></textarea>
+            </section>
+
+            <section class="preview">
+                <div class="tabs">
+                    <button class="tab ${previewTab == 0 ? 'tab--active' : ''}" @click="setTab(0)">Preview</button>
+                    <button class="tab ${previewTab == 1 ? 'tab--active' : ''}" @click="setTab(1)">JavaScript</button>
+                    <button class="tab ${previewTab == 2 ? 'tab--active' : ''}" @click="setTab(2)">CSS</button>
+                </div>
+                <div class="preview__body">
+                    <div class="banner banner--error" :if="hasError"><pre>${errorMsg}</pre></div>
+                    <iframe class="frame" :if="previewTab == 0" title="preview" sandbox="allow-scripts" :srcdoc="previewDoc"></iframe>
+                    <pre class="codeview" :if="previewTab == 1">${compiledJs}</pre>
+                    <pre class="codeview" :if="previewTab == 2">${previewCss}</pre>
+                </div>
+            </section>
+        </div>
+
+        <div class="modal" :if="showSamples">
+            <div class="modal__card">
+                <div class="modal__title">Samples</div>
+                <ul class="samplelist">
+                    <li :for="s of samples">
+                        <button class="sample" @click="loadSample(s.name)">${s.name}</button>
+                    </li>
+                </ul>
+                <div class="modal__actions">
+                    <button class="btn btn--ghost" @click="closeSamples()">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
 script:
-    let count = 0
-    function increment() {
-        count = count + 1
+    let files = pg.loadFiles()
+    let activeIndex = 0
+    let previewTab = 0
+    let previewDoc = ""
+    let compiledJs = ""
+    let previewCss = ""
+    let errorMsg = ""
+    let hasError = false
+    let showSamples = false
+    let samples = pg.samples()
+
+    function setEditorValue() {
+        const el = document.getElementById("code-editor")
+        if (el) el.value = files[activeIndex].content
     }
-    function reset() {
-        count = 0
+
+    async function recompile() {
+        pg.saveFiles(files)
+        const active = files[activeIndex]
+        const res = await pg.build(files, active.name)
+        if (res.error) {
+            hasError = true
+            errorMsg = res.error
+            return
+        }
+        hasError = false
+        errorMsg = ""
+        previewDoc = res.doc
+        compiledJs = res.activeJs
+        previewCss = res.css
     }
+
+    function onInput(e) {
+        files[activeIndex].content = e.target.value
+        files = [...files]
+        recompile()
+    }
+
+    function selectFile(name) {
+        activeIndex = files.findIndex(f => f.name == name)
+        setEditorValue()
+        recompile()
+    }
+
+    function addFile() {
+        const name = prompt("New file name (without .lunas)")
+        if (!name) return
+        if (files.find(f => f.name == name)) {
+            alert("A file named " + name + " already exists.")
+            return
+        }
+        files = [...files, { name: name, content: "" }]
+        activeIndex = files.length - 1
+        setEditorValue()
+        recompile()
+    }
+
+    function renameFile(name) {
+        const i = files.findIndex(f => f.name == name)
+        const next = prompt("Rename file", name)
+        if (!next || next == name) return
+        if (files.find(f => f.name == next)) {
+            alert("A file named " + next + " already exists.")
+            return
+        }
+        files[i].name = next
+        files = [...files]
+        recompile()
+    }
+
+    function deleteFile(name) {
+        if (files.length <= 1) return
+        if (!confirm("Delete " + name + ".lunas?")) return
+        const i = files.findIndex(f => f.name == name)
+        files = files.filter((f, idx) => idx != i)
+        if (activeIndex >= files.length) activeIndex = files.length - 1
+        setEditorValue()
+        recompile()
+    }
+
+    function setTab(tab) {
+        previewTab = tab
+    }
+
+    function openSamples() {
+        showSamples = true
+    }
+
+    function closeSamples() {
+        showSamples = false
+    }
+
+    function loadSample(name) {
+        const s = samples.find(x => x.name == name)
+        if (!s) return
+        if (!confirm("Load sample '" + s.name + "'? This replaces your files.")) return
+        files = s.files.map(f => ({ name: f.name, content: f.content }))
+        activeIndex = 0
+        showSamples = false
+        setEditorValue()
+        recompile()
+    }
+
+    requestAnimationFrame(setEditorValue)
+    recompile()

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="vite/client" />
+
+// The Lunas runtime, bundled to a single ESM source string at build time
+// (see the `lunasRuntimeVirtual` plugin in vite.config.ts).
+declare module "virtual:lunas-runtime" {
+  const source: string;
+  export default source;
+}
+
+// The wasm-pack `web` glue for the browser compiler build (in wasm/web).
+declare module "*/lunas_wasm.js" {
+  export default function init(input?: string | URL | Request): Promise<unknown>;
+  export function compile(source: string): {
+    code: string | null;
+    diagnostics: { severity: string; message: string; start: number; end: number }[];
+  };
+  export function version(): string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,13 @@
 import { attach } from "lunas";
+import { api } from "./playground.js";
 import App from "./App.lunas";
+import "./styles.css";
 
-// A compiled Lunas component's default export is a factory: call it to build a
-// detached root, then `attach` it to a host element in the DOM.
+// Install the playground API on the global object before the UI mounts: the
+// Lunas `script:` blocks reach it via `globalThis.pg` (they can't `import`).
+globalThis.pg = api;
+
+// Warm up the wasm compiler in the background so the first preview is snappy.
+api.initCompiler();
+
 attach(App(), document.getElementById("app")!);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,0 +1,51 @@
+// The bridge between the Lunas UI and the (non-reactive) TypeScript logic.
+//
+// Lunas `script:` blocks can't yet `import` modules, so `main.ts` installs this
+// API on `globalThis.pg` and the `.lunas` components call into it. Everything
+// here is a plain async/pure function — the reactive state lives in the Lunas
+// components.
+import { buildPreview, initCompiler, type LunasFile, type PreviewBuild } from "./preview/engine.js";
+import { DEFAULT_FILES, SAMPLES, type Sample } from "./samples.js";
+
+const STORAGE_KEY = "lunas-playground.files.v1";
+
+function loadFiles(): LunasFile[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return structuredClone(DEFAULT_FILES);
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+  } catch {
+    // fall through to defaults on any corruption
+  }
+  return structuredClone(DEFAULT_FILES);
+}
+
+function saveFiles(files: LunasFile[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(files));
+  } catch {
+    // ignore quota / privacy-mode failures — persistence is best-effort
+  }
+}
+
+export interface PlaygroundApi {
+  loadFiles(): LunasFile[];
+  saveFiles(files: LunasFile[]): void;
+  build(files: LunasFile[], activeName: string): Promise<PreviewBuild>;
+  samples(): Sample[];
+  initCompiler(): Promise<unknown>;
+}
+
+export const api: PlaygroundApi = {
+  loadFiles,
+  saveFiles,
+  build: (files, activeName) => buildPreview(files, activeName),
+  samples: () => SAMPLES,
+  initCompiler,
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var pg: PlaygroundApi;
+}

--- a/src/preview/engine.ts
+++ b/src/preview/engine.ts
@@ -1,0 +1,127 @@
+// The preview engine: compile every `.lunas` file in the project with the
+// browser (wasm-pack `web`) build of the Lunas compiler, then assemble a
+// self-contained HTML document that mounts the entry component.
+//
+// Two constraints shape the assembly:
+//   1. The live preview runs in a `sandbox="allow-scripts"` iframe, whose
+//      opaque origin blocks blob: URLs — so every module is inlined as a
+//      `data:` URL and wired together with an import map.
+//   2. The current Lunas codegen does not emit `style:` blocks, so we extract
+//      them from the source ourselves and inject a `<style>` into the document.
+import runtimeSource from "virtual:lunas-runtime";
+import init, { compile } from "../../wasm/web/lunas_wasm.js";
+import wasmUrl from "../../wasm/web/lunas_wasm_bg.wasm?url";
+import { bareifyImports, dataModule, extractStyle } from "./transform.mjs";
+
+export { extractStyle } from "./transform.mjs";
+
+export interface Diagnostic {
+  severity: string;
+  message: string;
+  start: number;
+  end: number;
+}
+
+export interface CompileResult {
+  code: string | null;
+  diagnostics: Diagnostic[];
+}
+
+export interface LunasFile {
+  name: string;
+  content: string;
+}
+
+export interface PreviewBuild {
+  doc: string;
+  activeJs: string;
+  css: string;
+  error: string | null;
+}
+
+let ready: Promise<unknown> | null = null;
+
+/** Lazily initialize the wasm compiler (idempotent). */
+export function initCompiler(): Promise<unknown> {
+  return (ready ??= init(wasmUrl));
+}
+
+/** Compile a single `.lunas` source string to JS + diagnostics. */
+export async function compileSource(source: string): Promise<CompileResult> {
+  await initCompiler();
+  return compile(source) as CompileResult;
+}
+
+/**
+ * Compile all files and assemble the preview document. `entryName` is the file
+ * whose default export is mounted (conventionally `App`); `activeName` selects
+ * which file's compiled JS is returned for the "JavaScript" pane.
+ */
+export async function buildPreview(
+  files: LunasFile[],
+  activeName: string,
+  entryName = "App",
+): Promise<PreviewBuild> {
+  const modules: Record<string, string> = {};
+  let css = "";
+  let activeJs = "";
+
+  for (const file of files) {
+    const result = await compileSource(file.content);
+    const err = result.diagnostics?.find((d) => d.severity === "error");
+    if (err) {
+      return {
+        doc: "",
+        activeJs: "",
+        css: "",
+        error: `${file.name}.lunas: ${err.message}`,
+      };
+    }
+    const code = result.code ?? "";
+    modules[file.name] = bareifyImports(code);
+    const style = extractStyle(file.content);
+    if (style) css += style + "\n";
+    if (file.name === activeName) activeJs = code;
+  }
+
+  const imports: Record<string, string> = {
+    lunas: dataModule(runtimeSource),
+  };
+  for (const name of Object.keys(modules)) {
+    imports[name] = dataModule(modules[name]);
+  }
+
+  const importMap = JSON.stringify({ imports });
+  // `component()` roots are a single Element (attach handles them); a multi-root
+  // template compiles to `fragment()`, whose factory returns an array of nodes
+  // that `attach` can't appendChild. Append those directly, then fire the
+  // subtree's onMount via a marker carrying the fragment's context.
+  const entry = [
+    `import App from ${JSON.stringify(entryName)};`,
+    `import { attach } from "lunas";`,
+    `const host = document.getElementById("app");`,
+    `const root = App();`,
+    `if (Array.isArray(root)) {`,
+    `  for (const n of root) host.appendChild(n);`,
+    `  const marker = document.createComment("");`,
+    `  marker.__lunasCtx = root.__lunasCtx;`,
+    `  attach(marker, host);`,
+    `} else {`,
+    `  attach(root, host);`,
+    `}`,
+  ].join("\n");
+
+  const doc = [
+    "<!doctype html>",
+    '<html><head><meta charset="utf-8">',
+    "<style>:root{color-scheme:light}body{margin:0;font-family:system-ui,sans-serif}</style>",
+    `<style>${css}</style>`,
+    "</head><body>",
+    '<div id="app"></div>',
+    `<script type="importmap">${importMap}</script>`,
+    `<script type="module">${entry}</script>`,
+    "</body></html>",
+  ].join("");
+
+  return { doc, activeJs, css, error: null };
+}

--- a/src/preview/transform.d.mts
+++ b/src/preview/transform.d.mts
@@ -1,0 +1,3 @@
+export function extractStyle(source: string): string;
+export function bareifyImports(code: string): string;
+export function dataModule(code: string): string;

--- a/src/preview/transform.mjs
+++ b/src/preview/transform.mjs
@@ -1,0 +1,58 @@
+// Pure, dependency-free source transforms used when assembling the preview.
+// Kept as plain ESM (with a sibling .d.ts) and separate from engine.ts — which
+// pulls in the wasm compiler and the bundled-runtime virtual module — so they
+// can be unit-tested under `node --test` without a browser or the wasm binary.
+
+/**
+ * Pull the raw CSS out of a `.lunas` `style:` block. The format is
+ * indentation-based: `style:` on its own line, then the block body indented
+ * beneath it until the next top-level line. The current codegen drops styles,
+ * so the playground extracts and injects them into the preview itself.
+ * @param {string} source
+ * @returns {string}
+ */
+export function extractStyle(source) {
+  const lines = source.split("\n");
+  const out = [];
+  let inStyle = false;
+  let indent = 0;
+  for (const line of lines) {
+    if (!inStyle) {
+      if (/^style:\s*$/.test(line)) {
+        inStyle = true;
+        indent = 0;
+      }
+      continue;
+    }
+    if (line.trim() === "") {
+      out.push("");
+      continue;
+    }
+    const lead = line.length - line.trimStart().length;
+    if (lead === 0) break; // dedent to a new top-level block ends the style
+    if (indent === 0) indent = lead;
+    out.push(line.slice(Math.min(indent, lead)));
+  }
+  return out.join("\n").trim();
+}
+
+/**
+ * Rewrite sibling component imports (`from "./Foo.lunas"`) to bare specifiers
+ * (`from "Foo"`) so an import map can resolve them across `data:` URL modules
+ * (a relative specifier would resolve against the importing data: URL, which
+ * has no meaningful base, rather than against the map).
+ * @param {string} code
+ * @returns {string}
+ */
+export function bareifyImports(code) {
+  return code.replace(/from\s*(["'])\.\/([^"']+?)\.lunas\1/g, 'from "$2"');
+}
+
+/**
+ * Encode a module's source as a `data:` URL usable from a sandboxed iframe.
+ * @param {string} code
+ * @returns {string}
+ */
+export function dataModule(code) {
+  return "data:text/javascript;charset=utf-8," + encodeURIComponent(code);
+}

--- a/src/samples.ts
+++ b/src/samples.ts
@@ -1,0 +1,92 @@
+// Seed content + loadable samples for the playground. Kept in TypeScript (not
+// fetched) so the playground works offline and on GitHub Pages with no backend.
+import type { LunasFile } from "./preview/engine.js";
+
+export interface Sample {
+  name: string;
+  files: LunasFile[];
+}
+
+const COUNTER = `html:
+    <main class="app">
+        <h1>Lunas Counter</h1>
+        <p>Count: \${count}</p>
+        <button @click="increment()">+1</button>
+        <button @click="reset()">Reset</button>
+        <p :if="count == 0">Click the button to begin.</p>
+        <p :elseif="count > 5">You are on a roll!</p>
+        <p :else>Keep going.</p>
+    </main>
+
+style:
+    .app { font-family: system-ui, sans-serif; max-width: 32rem; margin: 2rem auto; }
+    h1 { color: #6200ea; }
+    button { margin-right: 0.5rem; padding: 0.4rem 0.9rem; }
+
+script:
+    let count = 0
+    function increment() { count = count + 1 }
+    function reset() { count = 0 }
+`;
+
+const TODO = `html:
+    <main class="todo">
+        <h1>Todos</h1>
+        <input ::value="draft" placeholder="What needs doing?" />
+        <button @click="add()">Add</button>
+        <ul>
+            <li :for="item of items">\${item}</li>
+        </ul>
+        <p :if="items.length == 0">Nothing yet.</p>
+    </main>
+
+style:
+    .todo { font-family: system-ui, sans-serif; max-width: 32rem; margin: 2rem auto; }
+    input { padding: 0.4rem; }
+
+script:
+    let draft = ""
+    let items = []
+    function add() {
+        if (draft.length == 0) return
+        items = [...items, draft]
+        draft = ""
+    }
+`;
+
+const GREETING_APP = `@use Greeting from "./Greeting.lunas"
+html:
+    <main class="app">
+        <h1>Components</h1>
+        <input ::value="who" />
+        <Greeting :name="who" />
+    </main>
+
+style:
+    .app { font-family: system-ui, sans-serif; max-width: 32rem; margin: 2rem auto; }
+
+script:
+    let who = "world"
+`;
+
+const GREETING_CHILD = `@input name:string
+html:
+    <p class="greeting">Hello, \${name}!</p>
+
+style:
+    .greeting { color: #00897b; font-size: 1.2rem; }
+`;
+
+export const DEFAULT_FILES: LunasFile[] = [{ name: "App", content: COUNTER }];
+
+export const SAMPLES: Sample[] = [
+  { name: "Counter", files: [{ name: "App", content: COUNTER }] },
+  { name: "Todo list", files: [{ name: "App", content: TODO }] },
+  {
+    name: "Components",
+    files: [
+      { name: "App", content: GREETING_APP },
+      { name: "Greeting", content: GREETING_CHILD },
+    ],
+  },
+];

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,316 @@
+/* Playground chrome — a light, flat Material-ish look (deep-purple accent on a
+   light-blue toolbar), reproducing the previous Vuetify playground without the
+   framework or heavy effects. */
+
+:root {
+  --primary: #e3f2fd; /* blue lighten-5 (old toolbar color) */
+  --accent: #6200ea; /* deep-purple accent */
+  --bg: #ffffff;
+  --panel: #fafafa;
+  --border: #e0e0e0;
+  --text: #212121;
+  --muted: #616161;
+  --active-bg: #ede7f6; /* deep-purple lighten-5 */
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+}
+
+#app,
+.app {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--text);
+  background: var(--bg);
+}
+
+/* Top bar */
+.topbar {
+  height: 48px;
+  flex: 0 0 48px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  background: var(--primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  z-index: 2;
+}
+
+.topbar__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.topbar__spacer {
+  flex: 1;
+}
+
+/* Body split */
+.body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+/* Explorer */
+.explorer {
+  flex: 0 0 220px;
+  border-right: 1px solid var(--border);
+  background: var(--panel);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.explorer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.filelist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+}
+
+.file {
+  display: flex;
+  align-items: center;
+  padding: 0 4px 0 12px;
+}
+
+.file--active {
+  background: var(--active-bg);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.file__name {
+  flex: 1;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 6px 0;
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.file__act {
+  opacity: 0;
+}
+
+.file:hover .file__act {
+  opacity: 1;
+}
+
+/* Editor + preview panes */
+.editor,
+.preview {
+  flex: 1 1 50%;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.editor {
+  border-right: 1px solid var(--border);
+}
+
+.tabs {
+  height: 40px;
+  flex: 0 0 40px;
+  display: flex;
+  align-items: stretch;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+
+.tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  background: var(--bg);
+}
+
+.code {
+  flex: 1;
+  width: 100%;
+  border: none;
+  resize: none;
+  padding: 12px;
+  font-family: "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  tab-size: 4;
+  outline: none;
+  color: var(--text);
+}
+
+.preview__body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
+.frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: #fff;
+}
+
+.codeview {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  padding: 12px;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre;
+  background: #fbfbfb;
+}
+
+.banner {
+  position: absolute;
+  inset: 0;
+  padding: 16px;
+  overflow: auto;
+  z-index: 1;
+}
+
+.banner--error {
+  background: #fff5f5;
+  color: #c62828;
+}
+
+.banner--error pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+}
+
+/* Buttons */
+.btn {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 6px 14px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+}
+
+.btn--ghost {
+  background: rgba(98, 0, 234, 0.08);
+  color: var(--accent);
+}
+
+.btn--ghost:hover {
+  background: rgba(98, 0, 234, 0.16);
+}
+
+.icon-btn {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  border-radius: 4px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.icon-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--text);
+}
+
+/* Samples modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.modal__card {
+  background: #fff;
+  border-radius: 8px;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.modal__title {
+  padding: 16px 20px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+}
+
+.samplelist {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  max-height: 50vh;
+  overflow: auto;
+}
+
+.sample {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px 20px;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.sample:hover {
+  background: var(--active-bg);
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+}

--- a/test/transform.test.mjs
+++ b/test/transform.test.mjs
@@ -1,0 +1,41 @@
+// Unit tests for the preview source transforms — pure, no wasm, no browser.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractStyle, bareifyImports, dataModule } from "../src/preview/transform.mjs";
+
+test("extractStyle pulls the dedented style: block body", () => {
+  const src = [
+    "html:",
+    "    <p>hi</p>",
+    "style:",
+    "    .a { color: red; }",
+    "    .b { margin: 0; }",
+    "script:",
+    "    let n = 0",
+  ].join("\n");
+  assert.equal(extractStyle(src), ".a { color: red; }\n.b { margin: 0; }");
+});
+
+test("extractStyle returns empty when there is no style block", () => {
+  assert.equal(extractStyle("html:\n    <p>hi</p>\nscript:\n    let n = 0"), "");
+});
+
+test("bareifyImports rewrites sibling .lunas imports to bare specifiers", () => {
+  const code = 'import Child from "./Child.lunas";\nimport { x } from "lunas";';
+  assert.equal(
+    bareifyImports(code),
+    'import Child from "Child";\nimport { x } from "lunas";',
+  );
+});
+
+test("bareifyImports leaves the runtime import untouched", () => {
+  const code = 'import { component } from "lunas";';
+  assert.equal(bareifyImports(code), code);
+});
+
+test("dataModule produces a decodable text/javascript data URL", () => {
+  const code = 'export default 1 + 1; // ${weird} & chars';
+  const url = dataModule(code);
+  assert.ok(url.startsWith("data:text/javascript;charset=utf-8,"));
+  assert.equal(decodeURIComponent(url.split(",").slice(1).join(",")), code);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,43 @@
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+import { build as esbuild } from "esbuild";
 import lunas from "vite-plugin-lunas";
 
-// The plugin compiles `.lunas` components at build time via the wasm-pack
-// `nodejs` bindings built by `pnpm wasm:build` into `wasm/node` (see
-// scripts/build-wasm.mjs). Resolved from this file's URL — no absolute paths.
+// The plugin compiles the playground's own `.lunas` UI at build time via the
+// wasm-pack `nodejs` bindings built by `pnpm wasm:build` into `wasm/node`.
+// Resolved from this file's URL — no absolute paths (see scripts/build-wasm.mjs).
 const wasmPkgPath = fileURLToPath(new URL("./wasm/node", import.meta.url));
 
+// The live preview runs user code inside a sandboxed iframe, which needs the
+// Lunas runtime as a single self-contained ES module. Bundle it once (from the
+// submodule) and expose the source text as `virtual:lunas-runtime`, so the
+// preview engine can inline it as a data: URL (blob: URLs are blocked in the
+// iframe's opaque origin).
+function lunasRuntimeVirtual(): Plugin {
+  const id = "virtual:lunas-runtime";
+  const resolved = "\0" + id;
+  const entry = fileURLToPath(
+    new URL("./external/lunas/packages/lunas/src/index.mjs", import.meta.url),
+  );
+  return {
+    name: "lunas-runtime-virtual",
+    resolveId(source) {
+      return source === id ? resolved : null;
+    },
+    async load(loadId) {
+      if (loadId !== resolved) return null;
+      const result = await esbuild({
+        entryPoints: [entry],
+        bundle: true,
+        format: "esm",
+        platform: "browser",
+        write: false,
+      });
+      return `export default ${JSON.stringify(result.outputFiles[0].text)};`;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [lunas({ wasmPkgPath })],
+  plugins: [lunas({ wasmPkgPath }), lunasRuntimeVirtual()],
 });


### PR DESCRIPTION
Second of two migration PRs (after #5). Builds the full playground UI on the reset scaffold — **authored in `.lunas`**, compiled by the real Lunas compiler.

## What's here
- **`src/App.lunas`** — the whole UI: a light Material-ish shell (light-blue toolbar, deep-purple accents), a **VS Code-like file explorer** (add / rename / delete + `localStorage` persistence), an editor, a **Preview / JavaScript / CSS** pane, and a samples modal. State + reactivity live in Lunas; heavy logic (compile, iframe assembly, storage) is plain TS reached via `globalThis.pg` (Lunas `script:` blocks can't `import` modules yet).
- **`src/preview/engine.ts`** — compiles every file with the browser (wasm-pack `web`) build, assembles a sandboxed-iframe document, and mounts the entry. Modules are inlined as `data:` URLs + an import map (blob: URLs are blocked in the iframe's opaque origin). `style:` blocks are extracted and injected (current codegen drops them). Multi-root (`fragment`) entries are appended + mounted explicitly.
- **`src/preview/transform.mjs`** — pure transforms, unit-tested without wasm.
- **`vite.config.ts`** — a virtual module bundles the runtime to a single ESM for the preview iframe.

## Verified (headless Chromium)
Live compile + preview of the Counter / Todo / Components samples, edit-to-recompile, tab switching, and sample loading — no page errors. Gate green: `pnpm build`, `typecheck`, `test` (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)