### PR TITLE
feat(deploy): publish the playground to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow the deploy job to publish to Pages; one concurrent deploy at a time.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (incl. wasm)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install Rust toolchain (from submodule) + wasm target
+        working-directory: external/lunas/crates
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup target add wasm32-unknown-unknown
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            external/lunas/crates/target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('external/lunas/crates/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm-
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build wasm bindings
+        run: pnpm wasm:build
+
+      - name: Build site
+        run: pnpm build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/roadmap.yml
+++ b/roadmap.yml
@@ -60,4 +60,4 @@ milestones:
     items:
       - id: gh-pages
         title: GitHub Pages deploy on push to main (build incl. wasm, base path)
-        status: todo
+        status: done


### PR DESCRIPTION
Final roadmap step: deploy the playground to **GitHub Pages** on every push to `main`.

- `.github/workflows/deploy.yml` — checkout (recursive submodules) → Rust + wasm-pack → `pnpm wasm:build` → `pnpm build` → upload `dist/` → `deploy-pages`.
- Pages source is set to **GitHub Actions**; Vite `base: "./"` (already in place) keeps assets/workers/wasm resolving under the `/playground/` project-pages path.

Site: **https://lunasrun.github.io/playground/** (live after this merges and the deploy workflow runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)